### PR TITLE
Rework internal key derivation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/cybele-labs/cybele-core"
 description = "Cryptographic library for the cybele password manager."
 
 [dependencies]
-argon2 = "0.4.1"
+argon2 = "0.5.3"
 chacha20poly1305 = "0.10.0"
 hkdf = "0.12.3"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,4 @@ description = "Cryptographic library for the cybele password manager."
 [dependencies]
 argon2 = "0.5.3"
 chacha20poly1305 = "0.10.0"
-hkdf = "0.12.3"
 rand = "0.8.5"
-# TODO: remove sha2 once we're able to remove hkdf which depends on it
-sha2 = "0.10.1"

--- a/src/crypto/cipher.rs
+++ b/src/crypto/cipher.rs
@@ -17,9 +17,14 @@ pub fn decrypt(key: [u8; 32], ciphertext: &[u8]) -> Option<Vec<u8>> {
 mod tests {
     use super::*;
 
+    use rand::rngs::OsRng;
+    use rand::RngCore;
+
     #[test]
     fn encrypt_decrypt() {
-        let key: [u8; 32] = [1u8; 32];
+        let mut csprng = OsRng {};
+        let mut key: [u8; 32] = [0u8; 32];
+        csprng.fill_bytes(&mut key);
         let message: &[u8] = b"this is very secret";
         let encrypted = encrypt(key, message).unwrap();
         let decrypted = decrypt(key, encrypted.as_slice()).unwrap();

--- a/src/crypto/hmac256.rs
+++ b/src/crypto/hmac256.rs
@@ -1,0 +1,68 @@
+use std::io::Write;
+
+use crate::hash::sha256;
+
+/// Compute the HMAC-SHA256 for the given message.
+/// We only support keys smaller than 64 bytes, which avoids an additional hashing.
+pub fn authenticate(key: &[u8], message: &[u8]) -> [u8; 32] {
+    assert!(key.len() <= 64);
+    // SHA256 uses 64 bytes blocks, so we must expand our key: K0 = K || 0x00...
+    // We first compute SHA256((K0 ^ ipad) || message).
+    let mut inner_data: Vec<u8> = Vec::with_capacity(64 + message.len());
+    key.iter().for_each(|&x| inner_data.push(x ^ 0x36));
+    (0..(64 - key.len())).for_each(|_| inner_data.push(0x36));
+    inner_data.write_all(message).unwrap();
+    let inner_hash = sha256::hash(&inner_data);
+    // We then compute SHA256((K0 ^ opad) || SHA256((K0 ^ ipad) || message)).
+    let mut outer_data: Vec<u8> = Vec::with_capacity(96);
+    key.iter().for_each(|&x| outer_data.push(x ^ 0x5c));
+    (0..32).for_each(|_| outer_data.push(0x5c));
+    outer_data.write_all(&inner_hash).unwrap();
+    sha256::hash(&outer_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::hex;
+    use rand::rngs::OsRng;
+    use rand::{Rng, RngCore};
+
+    #[test]
+    fn authenticate_random_messages() {
+        let mut csprng = OsRng {};
+        let mut key: [u8; 32] = [0u8; 32];
+        csprng.fill_bytes(&mut key);
+        let message_size: usize = csprng.gen_range(1..1000);
+        let mut message: Vec<u8> = vec![0; message_size];
+        csprng.fill_bytes(&mut message);
+        let mac1: [u8; 32] = authenticate(&key, &message);
+        let mac2: [u8; 32] = authenticate(&key, &message);
+        assert_eq!(mac1, mac2);
+        let mac3: [u8; 32] = authenticate(&key, b"this is not the same message");
+        assert_ne!(mac1, mac3);
+        csprng.fill_bytes(&mut key);
+        let mac4: [u8; 32] = authenticate(&key, &message);
+        assert_ne!(mac1, mac4);
+    }
+
+    #[test]
+    fn test_vector() {
+        let key: [u8; 32] = hex::decode("a3a07ba8aaaeb0d60fad767437b544cbfd790a95702af8e0819f2eb706b46660").unwrap().try_into().unwrap();
+        let message = "cybele controls the keys to the world";
+        let expected: [u8; 32] = hex::decode("6397c4768a0a7b122dfbb5d45cd9a3cbed6a6c826365f133a331489ecc5fbcdf").unwrap().try_into().unwrap();
+        let mac = authenticate(&key, message.as_bytes());
+        assert_eq!(expected, mac);
+    }
+
+    // To run benchmarks:
+    //  - add #![feature(test)] to lib.rs
+    //  - add extern crate test; to lib.rs
+    //  - run cargo +nightly bench
+    // #[bench]
+    // fn bench_sha256(b: &mut Bencher) {
+    //     let key: [u8; 32] = hex::decode("a3a07ba8aaaeb0d60fad767437b544cbfd790a95702af8e0819f2eb706b46660").unwrap().try_into().unwrap();
+    //     b.iter(|| authenticate(&key, b"authentication matters folks"));
+    // }
+}

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -30,7 +30,7 @@ pub fn derive_key(version: Version, password: &str, salt: &[u8], purpose: Purpos
 
     // We first derive a 256-bit master key based on the password and salt.
     let mut master_key: [u8; 32] = [0u8; 32];
-    let salt_str: SaltString = SaltString::b64_encode(salt).map_err(|e| eprintln!("Invalid Argon2 salt: {}", e)).ok()?;
+    let salt_str: SaltString = SaltString::encode_b64(salt).map_err(|e| eprintln!("Invalid Argon2 salt: {}", e)).ok()?;
     let password_hash: Output = argon2
         .hash_password(password.as_bytes(), &salt_str)
         .map_err(|e| eprintln!("Cannot hash password: {}", e))

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,2 +1,3 @@
 pub mod cipher;
+pub mod hmac256;
 pub mod keys;

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -16,15 +16,12 @@ pub struct Vault {
 
 impl Vault {
     pub fn create(salt: Option<[u8; 32]>) -> Vault {
-        let salt: [u8; 32] = match salt {
-            Some(salt) => salt,
-            None => {
-                let mut csprng = OsRng {};
-                let mut salt: [u8; 32] = [0u8; 32];
-                csprng.fill_bytes(&mut salt);
-                salt
-            }
-        };
+        let salt: [u8; 32] = salt.unwrap_or_else(|| {
+            let mut csprng = OsRng {};
+            let mut salt: [u8; 32] = [0u8; 32];
+            csprng.fill_bytes(&mut salt);
+            salt
+        });
         Vault {
             version: Version::V1,
             salt,


### PR DESCRIPTION
Since we were using HKDF with 32-bytes outputs and SHA256 internally, it actually was using a single call to HMAC-SHA256. It's simpler and faster to directly use HMAC-SHA256, while providing the same security. We migrate to this and implement HMAC-SHA256 ourselves to get rid of the `hkf` and `sha2` dependencies entirely.

We also update our `Argon2` dependency in the first commit.